### PR TITLE
feat: реализация защиты панели (basicauth + секретный путь)

### DIFF
--- a/data/caddy/caddyfile-protected
+++ b/data/caddy/caddyfile-protected
@@ -1,0 +1,22 @@
+https://$PANEL_DOMAIN {
+    handle /api/* {
+        reverse_proxy http://remnawave:$PANEL_PORT
+    }
+
+    handle /$LOGIN_ROUTE* {
+        basicauth {
+            $ADMIN_LOGIN $ADMIN_PASSWORD_HASH
+        }
+        uri strip_prefix /$LOGIN_ROUTE
+        reverse_proxy http://remnawave:$PANEL_PORT
+    }
+
+    handle {
+        respond 404
+    }
+}
+
+:443 {
+    tls internal
+    respond 204
+}

--- a/data/caddy/caddyfile-protected
+++ b/data/caddy/caddyfile-protected
@@ -3,16 +3,11 @@ https://$PANEL_DOMAIN {
         reverse_proxy http://remnawave:$PANEL_PORT
     }
 
-    handle /$LOGIN_ROUTE* {
+    handle {
         basicauth {
             $ADMIN_LOGIN $ADMIN_PASSWORD_HASH
         }
-        uri strip_prefix /$LOGIN_ROUTE
         reverse_proxy http://remnawave:$PANEL_PORT
-    }
-
-    handle {
-        respond 404
     }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ cd "$TEMP_DIR" || exit 1
 
 echo "Downloading RemnaSetup..."
 echo "Загрузка RemnaSetup..."
-curl -L https://github.com/ANHELL-dev/RemnaSetup/archive/refs/heads/main.zip -o remnasetup.zip
+curl -L https://github.com/Capybara-z/RemnaSetup/archive/refs/heads/main.zip -o remnasetup.zip
 
 if [ ! -f remnasetup.zip ]; then
     echo "Error: Failed to download archive"

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ cd "$TEMP_DIR" || exit 1
 
 echo "Downloading RemnaSetup..."
 echo "Загрузка RemnaSetup..."
-curl -L https://github.com/Capybara-z/RemnaSetup/archive/refs/heads/main.zip -o remnasetup.zip
+curl -L https://github.com/ANHELL-dev/RemnaSetup/archive/refs/heads/main.zip -o remnasetup.zip
 
 if [ ! -f remnasetup.zip ]; then
     echo "Error: Failed to download archive"

--- a/scripts/remnawave/install-caddy.sh
+++ b/scripts/remnawave/install-caddy.sh
@@ -5,6 +5,7 @@ source "/opt/remnasetup/scripts/common/functions.sh"
 source "/opt/remnasetup/scripts/common/languages.sh"
 
 REINSTALL_CADDY=false
+NEED_PROTECTION=false
 
 check_component() {
     if [ -f "/opt/remnawave/caddy/docker-compose.yml" ] || [ -f "/opt/remnawave/caddy/Caddyfile" ]; then
@@ -44,13 +45,101 @@ install_docker() {
     fi
 }
 
+validate_password() {
+    local password="$1"
+    local prefix="$2"
+
+    if [[ ${#password} -lt 8 ]]; then
+        warn "$(get_string "${prefix}_password_short")"
+        return 1
+    fi
+    if ! [[ "$password" =~ [A-Z] ]]; then
+        warn "$(get_string "${prefix}_password_uppercase")"
+        return 1
+    fi
+    if ! [[ "$password" =~ [a-z] ]]; then
+        warn "$(get_string "${prefix}_password_lowercase")"
+        return 1
+    fi
+    if ! [[ "$password" =~ [0-9] ]]; then
+        warn "$(get_string "${prefix}_password_number")"
+        return 1
+    fi
+    if ! [[ "$password" =~ [^a-zA-Z0-9] ]]; then
+        warn "$(get_string "${prefix}_password_special")"
+        return 1
+    fi
+    return 0
+}
+
+request_protection_data() {
+    while true; do
+        question "$(get_string "install_caddy_need_protection")"
+        PROTECTION="$REPLY"
+        if [[ "$PROTECTION" == "y" || "$PROTECTION" == "Y" ]]; then
+            NEED_PROTECTION=true
+            break
+        elif [[ "$PROTECTION" == "n" || "$PROTECTION" == "N" ]]; then
+            NEED_PROTECTION=false
+            break
+        else
+            warn "$(get_string "install_caddy_please_enter_yn")"
+        fi
+    done
+
+    if [[ "$NEED_PROTECTION" == true ]]; then
+        while true; do
+            question "$(get_string "install_caddy_enter_login_route")"
+            LOGIN_ROUTE="$REPLY"
+            if [[ -n "$LOGIN_ROUTE" ]]; then
+                LOGIN_ROUTE="${LOGIN_ROUTE#/}"
+                break
+            fi
+            warn "$(get_string "install_caddy_login_route_empty")"
+        done
+
+        while true; do
+            question "$(get_string "install_caddy_enter_admin_login")"
+            ADMIN_LOGIN="$REPLY"
+            if [[ -n "$ADMIN_LOGIN" ]]; then
+                break
+            fi
+            warn "$(get_string "install_caddy_admin_login_empty")"
+        done
+
+        while true; do
+            question "$(get_string "install_caddy_enter_admin_password")"
+            ADMIN_PASSWORD="$REPLY"
+            if validate_password "$ADMIN_PASSWORD" "install_caddy"; then
+                break
+            fi
+        done
+    fi
+}
+
 install_caddy() {
     if [ "$REINSTALL_CADDY" = true ]; then
         info "$(get_string "install_caddy_installing")"
         mkdir -p /opt/remnawave/caddy
         cd /opt/remnawave/caddy
 
-        cp "/opt/remnasetup/data/caddy/caddyfile" Caddyfile
+        if [[ "$NEED_PROTECTION" == true ]]; then
+            cp "/opt/remnasetup/data/caddy/caddyfile-protected" Caddyfile
+
+            ADMIN_PASSWORD_HASH=$(docker run --rm caddy:2.9 caddy hash-password --plaintext "$ADMIN_PASSWORD" 2>/dev/null)
+            if [[ -z "$ADMIN_PASSWORD_HASH" ]]; then
+                error "Failed to generate password hash. Falling back to standard config."
+                cp "/opt/remnasetup/data/caddy/caddyfile" Caddyfile
+                NEED_PROTECTION=false
+            else
+                sed -i "s|\$LOGIN_ROUTE|$LOGIN_ROUTE|g" Caddyfile
+                sed -i "s|\$ADMIN_LOGIN|$ADMIN_LOGIN|g" Caddyfile
+                sed -i "s|\$ADMIN_PASSWORD_HASH|$ADMIN_PASSWORD_HASH|g" Caddyfile
+            fi
+        else
+            cp "/opt/remnasetup/data/caddy/caddyfile" Caddyfile
+        fi
+
         cp "/opt/remnasetup/data/docker/caddy-compose.yml" docker-compose.yml
 
         if [[ -n "$PANEL_DOMAIN" ]]; then
@@ -112,12 +201,33 @@ main() {
         SUB_PORT=""
     fi
 
+    if [[ -n "$PANEL_DOMAIN" ]]; then
+        request_protection_data
+    fi
+
     if ! check_docker; then
         install_docker
     fi
     install_caddy
 
     success "$(get_string "install_caddy_complete")"
+
+    if [[ "$NEED_PROTECTION" == true ]]; then
+        echo ""
+        echo -e "${MAGENTA}────────────────────────────────────────────────────────────${RESET}"
+        if [ "$LANGUAGE" = "en" ]; then
+            echo -e "${BOLD_CYAN}Panel Protection Info${RESET}"
+        else
+            echo -e "${BOLD_CYAN}Информация о защите панели${RESET}"
+        fi
+        echo -e "${MAGENTA}────────────────────────────────────────────────────────────${RESET}"
+        echo -e "${BOLD_GREEN}URL:${RESET} ${BLUE}https://${PANEL_DOMAIN}/${LOGIN_ROUTE}${RESET}"
+        echo -e "${BOLD_GREEN}Login:${RESET} ${BLUE}${ADMIN_LOGIN}${RESET}"
+        echo -e "${BOLD_GREEN}Password:${RESET} ${BLUE}${ADMIN_PASSWORD}${RESET}"
+        echo -e "${MAGENTA}────────────────────────────────────────────────────────────${RESET}"
+        echo ""
+    fi
+
     read -n 1 -s -r -p "$(get_string "install_caddy_press_key")"
     exit 0
 }


### PR DESCRIPTION
Реализована защита панели через Caddy basicauth — функционал, для которого уже были заготовлены языковые строки в languages.sh.

Что добавлено:
- Новый шаблон data/caddy/caddyfile-protected с basicauth
- Логика запроса защиты в install-caddy.sh и install-full.sh
- Валидация пароля, генерация bcrypt хеша через caddy hash-password
- Вывод данных доступа после установки

Как работает:
- При установке Caddy появляется вопрос "Требуется ли защита панели?"
- Если да — запрашивает логин и пароль
- /api/* остаётся открытым для нод
- Всё остальное закрыто basicauth
- Без пароля — 401 Unauthorized